### PR TITLE
Fix month picking for Plone 4.3 jQuery version.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix month picking for Plone 4.3 jQuery version.
+  [jone]
 
 
 1.1.7 (2013-03-17)

--- a/ftw/calendarwidget/browser/resources/ftw_calendar.js
+++ b/ftw/calendarwidget/browser/resources/ftw_calendar.js
@@ -57,7 +57,7 @@ function insert_date(date, e){
     yf.attr('value', e.selectedYear);
 
     var mf = $('#' + field_id +'_month');
-    mf.attr('value', $(mf.attr('options')[e.selectedMonth + 1]).attr('value'));
+    mf.find('option')[e.selectedMonth + 1].selected = true;
 
     var df = $('#'+ field_id +'_day');
     var day = e.selectedDay;
@@ -68,4 +68,3 @@ function insert_date(date, e){
     $('#' + field_id).trigger('calendar_after_change');
 
 }
-


### PR DESCRIPTION
`$('select').attr('options')` does no longer work.

/cc @maethu 
