### PR TITLE
Fix error on negative GMT timezones.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix JavaScript error when having a negative GMT timezone.
+  [jone]
 
 
 1.1.10 (2014-09-08)

--- a/ftw/calendarwidget/browser/resources/ftw_calendar.js
+++ b/ftw/calendarwidget/browser/resources/ftw_calendar.js
@@ -17,6 +17,9 @@ $(function(){
             default_value = $(this).children('input:first').attr('value');
 
             if (default_value.length){
+              /* Strip negative GMT-timezone in order to not match tests for "-" below.
+                 We dont need the timezone. */
+              default_value = default_value.replace(/ *gmt-\d{1,2}/i, '');
 
                 var temp;
                 if (default_value.search('-') !== -1){


### PR DESCRIPTION
As @rain2o reported in #16 there is a JavaScript error when using negative timezones (.e.g `GMT-5`).
The problem is that we support `/` as well as `-` as separator in the date/time string and the `GMT-5` matches a search for `-` but shouldn't.

This changes explicitly removes `GMT-*` timezone definitions before parsing.
Fixes #16 

@maethu please take a look :wink: 
