### PR TITLE
Fix bad widget JS declaration in order to support chameleon.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix bad widget JS declaration in order to support chameleon. [jone]
 
 
 1.1.11 (2014-10-02)

--- a/ftw/calendarwidget/browser/widgets.py
+++ b/ftw/calendarwidget/browser/widgets.py
@@ -13,6 +13,6 @@ class FtwCalendarWidget(CalendarWidget):
             'future_years': None,
             # XXX: helper_js does not make sense to me, because the js is
             # registered in jsregistry
-            'helper_js': ('ftw_calendar.js'),
+            'helper_js': ('ftw_calendar.js',),
             'helper_css': ('jscalendar/calendar-system.css',),
             })

--- a/ftw/calendarwidget/tests/test_integration.py
+++ b/ftw/calendarwidget/tests/test_integration.py
@@ -41,7 +41,7 @@ class TestCalendarwidget(TestCase):
             widget=FtwCalendarWidget(label='My Date')),
         ))
         widget = schema['mydate'].widget
-        self.assertEquals(widget.helper_js, 'ftw_calendar.js')
+        self.assertEquals(widget.helper_js, ('ftw_calendar.js',))
         self.assertEquals(widget.helper_css, ('jscalendar/calendar-system.css', ))
 
 

--- a/test-plone-4.3.x-chameleon.cfg
+++ b/test-plone-4.3.x-chameleon.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+
+package-name = ftw.calendarwidget
+test-egg += chameleon


### PR DESCRIPTION
Fix bad declaration of widget JS: it should be a tuple, not a string. This fixes chameleon support.